### PR TITLE
CAP-59 #comment added postgres user tier permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     
     # a DB container
     db:
-        image: postgres:9.5
+        image: postgres:latest
         environment:
             POSTGRES_USER: cc
             POSTGRES_PASSWORD: pp

--- a/sql/db-create.sql
+++ b/sql/db-create.sql
@@ -1,7 +1,6 @@
 /*
 This SQL file will be executed once the DB has set up.
 It will contain SQL command to set up required DBs and tables
-
 */
 
 CREATE TABLE IF NOT EXISTS test  (
@@ -21,3 +20,32 @@ CREATE TABLE IF NOT EXISTS metadata (
     title TEXT
 );
 
+-- Create groups
+CREATE ROLE readaccess;
+CREATE ROLE writeaccess;
+CREATE ROLE adminaccess;
+
+-- Remove default permissions
+REVOKE ALL ON SCHEMA public FROM public;
+
+-- Grant access to read group
+GRANT USAGE ON SCHEMA public TO readaccess;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO readaccess;
+
+-- Grant access to write group
+GRANT USAGE ON SCHEMA public TO writeaccess;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO writeaccess;
+
+-- Grant access to admin group
+GRANT ALL PRIVILEGES ON SCHEMA public TO adminaccess;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO adminaccess;
+
+-- Create users
+CREATE USER reader WITH PASSWORD 'capstone';
+CREATE USER writer WITH PASSWORD 'capstone';
+CREATE USER administrator WITH PASSWORD 'capstone';
+
+-- Grant group access
+GRANT readaccess TO reader;
+GRANT writeaccess TO writer;
+GRANT adminaccess TO administrator;


### PR DESCRIPTION
This MR introduced updates to db-create.sql to create three tiers of user permissions (readonly, read/write, and full admin). These permissions are applied at the schema/table level, not a full db scope level to provide better restriction of access. Note: this does not grant full owner access to the administrator group as a "feature" of how postgresql works. Only the 'cc' user used by the API itself remains the full owner of tables. 

Signed-off-by: Connor Kaz <connor4@pdx.edu>