### PR TITLE
Updated db-create/Driver.py

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -351,7 +351,8 @@ def insert_row(table, row, checked=False):
     cmd += ")"
     try:
         pgSqlCur.execute(cmd)
-
+        if not checked:
+            pgSqlConn.commit()
         if pgSqlCur.rowcount == 1:
             return 1, None
         else:


### PR DESCRIPTION
Cap-92: Added a new column to txn_history table, archive_row.  This is a FK to the Archive table that holds the row the delete recorded is stored at in archive.  Added back in MRL check as part of PK.  Updated driver to commit file in insert row function (This could have caused issues with mulitple users posting to the db at same time with same data but it not getting caught).