### PR TITLE
Cap 94/95   model reports/violations table

### DIFF
--- a/db/db-create.sql
+++ b/db/db-create.sql
@@ -13,7 +13,7 @@ This SQL file will be executed once the DB is set up.
 --  	 JSON. In case of DELETE it copies data into archive table then updates txn_history
 --       with location data for archive table
 --
-CREATE function change_fnc() RETURNS trigger
+CREATE function change_fnc() RETURNS TRIGGER
     LANGUAGE plpgsql
     AS $$BEGIN
 IF TG_OP='INSERT'
@@ -40,12 +40,12 @@ $$;
 alter function change_fnc() OWNER TO cc;
 
 --
--- A trigger for insert conflict strategy
+-- A TRIGGER for insert conflict strategy
 -- Name: check_insertion_fnc; Type: TRIGGER; Schema: public; Owner: cc
 --
 
 CREATE function check_insertion_fnc()
-    RETURNS trigger
+    RETURNS TRIGGER
     LANGUAGE 'plpgsql'
 AS $BODY$BEGIN
 CASE when NEW.dba IS NULL
@@ -313,40 +313,40 @@ ALTER SEQUENCE records_row_seq OWNED BY records.row_id;
 ALTER TABLE ONLY records ALTER COLUMN row_id SET DEFAULT nextval('records_row_seq'::regclass);
 
 -------------------------
--- Triggers
+-- TRIGGERs
 -------------------------
 
 --
 -- Name: intake_transactions
--- Desc: Monitor intake table, before any transaction calls function change_trigger
+-- Desc: Monitor intake table, before any transaction calls function change_TRIGGER
 --
-CREATE trigger intake_transactions
-before insert or update or delete on intake
-for each row EXECUTE function change_fnc();
+CREATE TRIGGER intake_transactions
+BEFORE INSERT OR UPDATE OR DELETE ON intake
+FOR EACH ROW EXECUTE FUNCTION change_fnc();
 
 --
 -- Name: intake_check_insertion
 -- Desc: Monitor intake table, before any INSERT calls function check_insertion_to_intake_tri_fnc
 --
-CREATE trigger intake_check_insertion
-before insert on intake
-for each row EXECUTE function check_insertion_fnc();
+CREATE TRIGGER intake_check_insertion
+BEFORE INSERT on intake
+FOR EACH ROW EXECUTE FUNCTION check_insertion_fnc();
 
 --
 -- Name: violations_transactions
 -- Desc: Monitor violations table, before any transaction calls function change_fnc
 --
-CREATE trigger violations_transactions
-before insert or update or delete on violations
-for each row EXECUTE function change_fnc();
+CREATE TRIGGER violations_transactions
+BEFORE INSERT OR UPDATE OR DELETE ON violations
+FOR EACH ROW EXECUTE FUNCTION change_fnc();
 
 --
 -- Name: records_transactions
 -- Desc: Monitor records table, before any transaction calls function change_fnc
 --
-CREATE trigger records_transactions
-before insert or update or delete on records
-for each row EXECUTE function change_fnc();
+CREATE TRIGGER records_transactions
+BEFORE INSERT OR UPDATE OR DELETE ON records
+FOR EACH ROW EXECUTE FUNCTION change_fnc();
 -------------------------
 -- Groups
 -------------------------

--- a/db/db-create.sql
+++ b/db/db-create.sql
@@ -210,7 +210,7 @@ ALTER TABLE ONLY violations
 create TABLE IF NOT EXISTS records
 (
     row_id integer NOT NULL,
-    "date" date,
+    date date,
     method text,
     intake_person text,
     rp_name text,

--- a/db/db-create.sql
+++ b/db/db-create.sql
@@ -295,6 +295,30 @@ COMMENT ON TABLE violations IS 'Table to hold all the information regarding viol
 ALTER TABLE ONLY violations
     ADD CONSTRAINT violations_pkey PRIMARY KEY (row_id);
 
+--
+-- Name: records Type: table Schema: public Owner: cc
+--
+create TABLE IF NOT EXISTS records
+(
+    row_id integer NOT NULL,
+    "date" date,
+    method text,
+    intake_person text,
+    rp_name text,
+    rp_contact_info text,
+    concern text,
+    location_name text,
+    address text,
+    mrl_num text,
+    action_taken text,
+    status text,
+    status_date date,
+    additional_notes text
+);
+ALTER TABLE records OWNER to cc;
+COMMENT ON TABLE records IS 'Table to hold all the information regarding violations.';
+ALTER TABLE ONLY records
+    ADD CONSTRAINT records_pkey PRIMARY KEY (row_id);
 -------------------------
 -- Sequences
 -------------------------
@@ -363,6 +387,21 @@ ALTER TABLE violations_row_seq OWNER TO cc;
 ALTER SEQUENCE violations_row_seq OWNED BY violations.row_id;
 ALTER TABLE ONLY violations ALTER COLUMN row_id SET DEFAULT nextval('violations_row_seq'::regclass);
 
+--
+-- Name: records_row_seq
+-- Desc: Sequence used as PK for records table Owner: cc
+--
+create SEQUENCE records_row_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER TABLE records_row_seq OWNER TO cc;
+ALTER SEQUENCE records_row_seq OWNED BY records.row_id;
+ALTER TABLE ONLY records ALTER COLUMN row_id SET DEFAULT nextval('records_row_seq'::regclass);
 -------------------------
 -- Triggers
 -------------------------
@@ -385,13 +424,19 @@ for each row EXECUTE function check_insertion_fnc();
 
 --
 -- Name: violations_transactions
--- Desc: Monitor intake table, before any transaction calls function change_trigger
+-- Desc: Monitor violations table, before any transaction calls function change_fnc
 --
 create trigger violations_transactions
 before insert or update or delete on violations
 for each row EXECUTE function violations_change_fnc();
 
-
+--
+-- Name: records_transactions
+-- Desc: Monitor records table, before any transaction calls function change_fnc
+--
+create trigger violations_transactions
+before insert or update or delete on violations
+for each row EXECUTE function violations_change_fnc();
 -------------------------
 -- Groups
 -------------------------

--- a/db/db-create.sql
+++ b/db/db-create.sql
@@ -329,7 +329,7 @@ FOR EACH ROW EXECUTE FUNCTION change_fnc();
 -- Desc: Monitor intake table, before any INSERT calls function check_insertion_to_intake_tri_fnc
 --
 CREATE TRIGGER intake_check_insertion
-BEFORE INSERT on intake
+BEFORE INSERT ON intake
 FOR EACH ROW EXECUTE FUNCTION check_insertion_fnc();
 
 --

--- a/db/db-create.sql
+++ b/db/db-create.sql
@@ -391,17 +391,4 @@ GRANT adminaccess TO administrator;
 ----------------------------
 --Dummy Data
 ----------------------------
-INSERT INTO violations ( dba, address, mrl_num, license_type, violation_sent_date,
-                        original_violation_amount, admin_rvw_decision_date, admin_rvw_violation_amount,
-                        certified_num, certified_receipt_returned, date_paid_waived,
-                        receipt_no, cash_amount, check_amount, card_amount, check_num_approval_code,
-                        notes)
-VALUES('Christ Smokes', '123 NE REffer Way', 'mrl#3', NULL,'12/12/20','$350', '1/1/19','$450',
-        '12345', 'yes', '4/5/12', '098000', '$100', '$250', '$100', NULL, NULL);
 
-INSERT INTO records("date", method, intake_person, rp_name, rp_contact_info,
-                    concern, location_name, address, mrl_num, action_taken,
-                    status, status_date, additional_notes)
-VALUES('12/4/2020', 'Phone Call', 'Joe Exotic', 'Gene Wilder', '606-999-0980',
-       'Selling drugs to minors', 'Christ Smokes', '123 NE reffer way', 'mrl#3',
-       'Fine levied against business', 'Closed', '1/1/2020', 'Testing');

--- a/db/db-create.sql
+++ b/db/db-create.sql
@@ -9,11 +9,11 @@ This SQL file will be executed once the DB is set up.
 --
 -- Name: change_fnc(); Type: FUNCTION; Schema: public; Owner: cc
 -- Desc: Monitors table for any insert/update/delete commands
--- 		 It copys the old data and the new data in txn_history table as 
+-- 		 It copies the old data and the new data in txn_history table as
 --  	 JSON. In case of DELETE it copies data into archive table then updates txn_history
 --       with location data for archive table
 --
-create function change_fnc() RETURNS trigger
+CREATE function change_fnc() RETURNS trigger
     LANGUAGE plpgsql
     AS $$BEGIN
 IF TG_OP='INSERT'
@@ -44,7 +44,7 @@ alter function change_fnc() OWNER TO cc;
 -- Name: check_insertion_fnc; Type: TRIGGER; Schema: public; Owner: cc
 --
 
-create function check_insertion_fnc()
+CREATE function check_insertion_fnc()
     RETURNS trigger
     LANGUAGE 'plpgsql'
 AS $BODY$BEGIN
@@ -91,11 +91,11 @@ SET default_table_access_method = heap;
 --
 -- Name: metadata; Type: TABLE; Schema: public; Owner: cc
 --
-create TABLE IF NOT EXISTS metadata (
+CREATE TABLE IF NOT EXISTS metadata (
     filename TEXT NOT NULL,
     creator TEXT,
     size INT,
-    created_date TIMESTAMP,
+    CREATEd_date TIMESTAMP,
     last_modified_date TIMESTAMP,
     last_modified_by TEXT,
     title TEXT,
@@ -108,7 +108,7 @@ COMMENT ON TABLE metadata IS 'Table to track the file metadata that is uploaded 
 --
 -- Name: Intake; Type: TABLE; Schema: public; Owner: cc
 --
-create TABLE intake (
+CREATE TABLE intake (
     "row" integer NOT NULL,
     submission_date date,
     entity text,
@@ -145,7 +145,7 @@ ALTER TABLE ONLY intake
 --
 -- Name: txn_history; Type: TABLE; Schema: public; Owner: cc
 --
-create TABLE txn_history (
+CREATE TABLE txn_history (
     id integer NOT NULL,
     tstamp timestamp without time zone DEFAULT now(),
     schemaname text,
@@ -164,7 +164,7 @@ ALTER TABLE ONLY txn_history
 --
 -- Name: archive; Type: TABLE; Schema: public; Owner: CC
 --
-create TABLE archive (
+CREATE TABLE archive (
     row_id integer NOT NULL,
     tstamp timestamp without time zone DEFAULT now(),
     who text DEFAULT CURRENT_USER,
@@ -178,7 +178,7 @@ ALTER TABLE ONLY archive
 --
 -- Name: violations Type: table Schema: public Owner: cc
 --
-create TABLE IF NOT EXISTS violations
+CREATE TABLE IF NOT EXISTS violations
 (
     row_id integer NOT NULL,
     dba text,
@@ -207,7 +207,7 @@ ALTER TABLE ONLY violations
 --
 -- Name: records Type: table Schema: public Owner: cc
 --
-create TABLE IF NOT EXISTS records
+CREATE TABLE IF NOT EXISTS records
 (
     row_id integer NOT NULL,
     date date,
@@ -236,7 +236,7 @@ ALTER TABLE ONLY records
 -- Name: intake_row_seq
 -- Desc: Sequence used as PK for intake table Owner: cc
 --
-create SEQUENCE intake_row_seq
+CREATE SEQUENCE intake_row_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -252,7 +252,7 @@ ALTER TABLE ONLY intake ALTER COLUMN "row" SET DEFAULT nextval('intake_row_seq':
 -- Name: txn_history_id_seq
 -- Desc: Sequence used as PK for txn_history table Owner: cc
 --
-create SEQUENCE txn_history_id_seq
+CREATE SEQUENCE txn_history_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -268,7 +268,7 @@ ALTER TABLE ONLY txn_history ALTER COLUMN id SET DEFAULT nextval('txn_history_id
 -- Name: archive_row_seq
 -- Desc: Sequence used as PK for archive table Owner: cc
 --
-create SEQUENCE archive_row_seq
+CREATE SEQUENCE archive_row_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -284,7 +284,7 @@ ALTER TABLE ONLY archive ALTER COLUMN row_id SET DEFAULT nextval('archive_row_se
 -- Name: violations_row_seq
 -- Desc: Sequence used as PK for violations table Owner: cc
 --
-create SEQUENCE violations_row_seq
+CREATE SEQUENCE violations_row_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -300,7 +300,7 @@ ALTER TABLE ONLY violations ALTER COLUMN row_id SET DEFAULT nextval('violations_
 -- Name: records_row_seq
 -- Desc: Sequence used as PK for records table Owner: cc
 --
-create SEQUENCE records_row_seq
+CREATE SEQUENCE records_row_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -320,7 +320,7 @@ ALTER TABLE ONLY records ALTER COLUMN row_id SET DEFAULT nextval('records_row_se
 -- Name: intake_transactions
 -- Desc: Monitor intake table, before any transaction calls function change_trigger
 --
-create trigger intake_transactions
+CREATE trigger intake_transactions
 before insert or update or delete on intake
 for each row EXECUTE function change_fnc();
 
@@ -328,7 +328,7 @@ for each row EXECUTE function change_fnc();
 -- Name: intake_check_insertion
 -- Desc: Monitor intake table, before any INSERT calls function check_insertion_to_intake_tri_fnc
 --
-create trigger intake_check_insertion
+CREATE trigger intake_check_insertion
 before insert on intake
 for each row EXECUTE function check_insertion_fnc();
 
@@ -336,7 +336,7 @@ for each row EXECUTE function check_insertion_fnc();
 -- Name: violations_transactions
 -- Desc: Monitor violations table, before any transaction calls function change_fnc
 --
-create trigger violations_transactions
+CREATE trigger violations_transactions
 before insert or update or delete on violations
 for each row EXECUTE function change_fnc();
 
@@ -344,24 +344,24 @@ for each row EXECUTE function change_fnc();
 -- Name: records_transactions
 -- Desc: Monitor records table, before any transaction calls function change_fnc
 --
-create trigger records_transactions
+CREATE trigger records_transactions
 before insert or update or delete on records
 for each row EXECUTE function change_fnc();
 -------------------------
 -- Groups
 -------------------------
 
-create ROLE readaccess;
-create ROLE writeaccess;
-create ROLE adminaccess;
+CREATE ROLE readaccess;
+CREATE ROLE writeaccess;
+CREATE ROLE adminaccess;
 
 -------------------------
 -- Users
 -------------------------
 
-create USER reader WITH PASSWORD 'capstone';
-create USER writer WITH PASSWORD 'capstone';
-create USER administrator WITH PASSWORD 'capstone';
+CREATE USER reader WITH PASSWORD 'capstone';
+CREATE USER writer WITH PASSWORD 'capstone';
+CREATE USER administrator WITH PASSWORD 'capstone';
 
 -------------------------
 -- Access

--- a/db/db-create.sql
+++ b/db/db-create.sql
@@ -13,7 +13,7 @@ This SQL file will be executed once the DB is set up.
 --  	 JSON. In case of DELETE it copies data into archive table then updates txn_history
 --       with location data for archive table
 --
-CREATE function change_fnc() RETURNS TRIGGER
+CREATE FUNCTION change_fnc() RETURNS TRIGGER
     LANGUAGE plpgsql
     AS $$BEGIN
 IF TG_OP='INSERT'
@@ -37,14 +37,14 @@ END IF;
 END;
 $$;
 
-alter function change_fnc() OWNER TO cc;
+ALTER FUNCTION change_fnc() OWNER TO cc;
 
 --
 -- A TRIGGER for insert conflict strategy
 -- Name: check_insertion_fnc; Type: TRIGGER; Schema: public; Owner: cc
 --
 
-CREATE function check_insertion_fnc()
+CREATE FUNCTION check_insertion_fnc()
     RETURNS TRIGGER
     LANGUAGE 'plpgsql'
 AS $BODY$BEGIN
@@ -75,7 +75,7 @@ END IF;
 END CASE;
 END;$BODY$;
 
-ALTER function check_insertion_fnc() OWNER TO cc;
+ALTER FUNCTION check_insertion_fnc() OWNER TO cc;
 
 -------------------------
 -- DB Parameters

--- a/db/db-create.sql
+++ b/db/db-create.sql
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS metadata (
     filename TEXT NOT NULL,
     creator TEXT,
     size INT,
-    CREATEd_date TIMESTAMP,
+    created_date TIMESTAMP,
     last_modified_date TIMESTAMP,
     last_modified_by TEXT,
     title TEXT,
@@ -386,9 +386,3 @@ GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO adminaccess;
 GRANT readaccess TO reader;
 GRANT writeaccess TO writer;
 GRANT adminaccess TO administrator;
-
-
-----------------------------
---Dummy Data
-----------------------------
-

--- a/driver.py
+++ b/driver.py
@@ -12,7 +12,7 @@ from validation import validate_data_file
 
 test_file = 'resources/sample.xlsx'
 primary_table = 'intake'
-db_tables = ['intake', 'txn_history', 'archive', 'metadata']
+db_tables = ['intake', 'txn_history', 'archive', 'metadata', 'violations', 'records']
 metadata_table = 'metadata'
 connection_error_msg = 'The connection to the database is closed and cannot be opened. Verify DB server is up.'
 

--- a/models/ArchiveRow.py
+++ b/models/ArchiveRow.py
@@ -8,33 +8,9 @@ class ArchiveRow:
         Default constructor.
         """
         self.row = None
-        self.old_row = None
-        self.old_submission_date = ''
-        self.old_entity = ''
-        self.old_dba = ''
-        self.old_facility_address = ''
-        self.old_facility_suite = ''
-        self.old_facility_zip = ''
-        self.old_mailing_address = ''
-        self.old_mrl = ''
-        self.old_neighborhood_assn = ''
-        self.old_compliance_region = ''
-        self.old_first_name = ''
-        self.old_last_name = ''
-        self.old_email = ''
-        self.old_phone = ''
-        self.old_endorse_type = ''
-        self.old_license_type = ''
-        self.old_repeat_license = ''
-        self.old_app_complete = ''
-        self.old_fee_schedule = ''
-        self.old_receipt_num = ''
-        self.old_cash_amt = ''
-        self.old_check_amt = ''
-        self.old_card_amt = ''
-        self.old_check_num = ''
-        self.old_mrl_num = ''
-        self.old_notes = ''
+        self.tstamp = ''
+        self.who =''
+        self.old_val=''
 
     def __init__(self, input_json):
         """
@@ -43,31 +19,8 @@ class ArchiveRow:
             input_json ({}): JSON object representing a row of the archive table
         """
         self.row = input_json.get('row')
-        self.old_row = input_json.get('old_row')
-        self.old_submission_date = input_json.get('old_submission_date')
-        self.old_entity = input_json.get('old_entity')
-        self.old_dba = input_json.get('old_dba')
-        self.old_facility_address = input_json.get('old_facility_address')
-        self.old_facility_suite = input_json.get('old_facility_suite')
-        self.old_facility_zip = input_json.get('old_facility_zip')
-        self.old_mailing_address = input_json.get('old_ailing_address')
-        self.old_mrl = input_json.get('old_mrl')
-        self.old_neighborhood_assn = input_json.get('old_neighborhood_association')
-        self.old_compliance_region = input_json.get('old_compliance_region')
-        self.old_first_name = input_json.get('old_primary_contact_first_name')
-        self.old_last_name = input_json.get('old_primary_contact_last_name')
-        self.old_email = input_json.get('old_email')
-        self.old_phone = input_json.get('old_phone')
-        self.old_endorse_type = input_json.get('old_endorse_type')
-        self.old_license_type = input_json.get('old_license_type')
-        self.old_repeat_license = input_json.get('old_repeat_location')
-        self.old_app_complete = input_json.get('old_app_complete')
-        self.old_fee_schedule = input_json.get('old_fee_schedule')
-        self.old_receipt_num = input_json.get('old_receipt_num')
-        self.old_cash_amt = input_json.get('old_ash_amount')
-        self.old_check_amt = input_json.get('old_check_amount')
-        self.old_card_amt = input_json.get('old_card_amount')
-        self.old_check_num = input_json.get('old_check_num_approval_code')
-        self.old_mrl_num = input_json.get('old_mrl_num')
-        self.old_notes = input_json.get('old_notes')
+        self.tstamp = input_json.get('tstamp')
+        self.who = input_json.get('who')
+        self.old_val = input_json.get('old_val')
+
 

--- a/models/RecordsRow.py
+++ b/models/RecordsRow.py
@@ -1,0 +1,76 @@
+from enum import Enum
+
+
+class RowNames(Enum):
+    ROW_ID = 0
+    DATE = 1
+    METHOD = 2
+    INTAKE_PERSON = 3
+    RP_NAME = 4
+    RP_CONTACT_INFO = 5
+    CONCERN = 6
+    LOCATION_NAME = 7
+    LOCATION_ADDRESS = 8
+    MRL = 9
+    ACTION_TAKEN = 10
+    STATUS = 11
+    STATUS_DATE = 12
+    ADDITIONAL_NOTES = 13
+
+
+
+class RecordsRow:
+    """
+    Represents a row of the records table.
+    """
+
+    def __init__(self):
+        """
+        Default constructor.
+        """
+        self.row_id = None
+        self.date = ''
+        self.method = ''
+        self.intake_person = ''
+        self.rp_name = ''
+        self.rp_contact_info = ''
+        self.concern = ''
+        self.location_name = ''
+        self.location_address = ''
+        self.mrl = ''
+        self.action_taken = ''
+        self.status = ''
+        self.status_date = ''
+        self.additional_notes = ''
+
+
+    def __init__(self, input_json):
+        """
+        Constructor from a JSON object. Any unsupplied data defaults to None
+        Args:
+            input_json ({}): JSON object representing a row of the intake table
+        """
+        self.row_id = input_json.get('row')
+        self.date = input_json.get('Date')
+        self.method = input_json.get('Method')
+        self.intake_person = input_json.get('Intake Person')
+        self.rp_name = input_json.get('RP (Name)')
+        self.rp_contact_info = input_json.get('RP (Contact Info)')
+        self.concern = input_json.get('Concern')
+        self.location_name = input_json.get('Location Name')
+        self.location_address = input_json.get('Location Address')
+        self.mrl = input_json.get('MRL?')
+        self.action_taken = input_json.get('Action Taken')
+        self.status = input_json.get('Status')
+        self.status_date = input_json.get('Status Date')
+        self.additional_notes = input_json.get('Additional Notes')
+
+
+    def value_array(self):
+        """
+        Order data into an array that can be consumed by the row insertion method.
+        Returns ([]): array of data members
+        """
+        return [self.row_id, self.date, self.method, self.intake_person, self.rp_name, self.rp_contact_info,
+                self.concern, self.location_name, self.location_address, self.mrl, self.action_taken,
+                self.status, self.status_date, self.additional_notes]

--- a/models/ReportsRow.py
+++ b/models/ReportsRow.py
@@ -18,10 +18,9 @@ class RowNames(Enum):
     ADDITIONAL_NOTES = 13
 
 
-
-class RecordsRow:
+class ReportsRow:
     """
-    Represents a row of the records table.
+    Represents a row of the reports table.
     """
 
     def __init__(self):
@@ -43,7 +42,6 @@ class RecordsRow:
         self.status_date = ''
         self.additional_notes = ''
 
-
     def __init__(self, input_json):
         """
         Constructor from a JSON object. Any unsupplied data defaults to None
@@ -64,7 +62,6 @@ class RecordsRow:
         self.status = input_json.get('Status')
         self.status_date = input_json.get('Status Date')
         self.additional_notes = input_json.get('Additional Notes')
-
 
     def value_array(self):
         """

--- a/models/ViolationsRow.py
+++ b/models/ViolationsRow.py
@@ -1,0 +1,87 @@
+from enum import Enum
+
+
+class RowNames(Enum):
+    ROW = 0
+    DBA = 1
+    ADDRESS = 2
+    MRL = 3
+    LICENSE_TYPE = 4
+    VIOLATION_SENT_DATE = 5
+    ORIGINAL_VIOLATION_AMOUNT = 6
+    ADMIN_RVW_DECISION_DATE = 7
+    ADMIN_RVW_VIOLATION_AMOUNT = 8
+    CERTIFIED_NUM = 9
+    CERTIFIED_RECEIPT_RETURNED = 10
+    DATE_PAID_WAIVED = 11
+    RECEIPT_NUM = 12
+    CASH_AMT = 13
+    CHECK_AMT = 14
+    CARD_AMT = 15
+    CHECK_NUM = 16
+    NOTES = 17
+
+
+class ViolationsRow:
+    """
+    Represents a row of the violations table.
+    """
+
+    def __init__(self):
+        """
+        Default constructor.
+        """
+        self.row_id = None
+        self.dba = ''
+        self.address = ''
+        self.mrl = ''
+        self.license_type = ''
+        self.violation_sent_date = ''
+        self.original_violation_amount = ''
+        self.admin_rvw_decision_date = ''
+        self.admin_rvw_violation_amount = ''
+        self.certified_num = ''
+        self.certified_reciept_returned = ''
+        self.date_paid_waived = ''
+        self.receipt_no = ''
+        self.cash_amt = ''
+        self.check_amt = ''
+        self.card_amt = ''
+        self.check_num = ''
+        self.notes = ''
+
+    def __init__(self, input_json):
+        """
+        Constructor from a JSON object. Any unsupplied data defaults to None
+        Args:
+            input_json ({}): JSON object representing a row of the intake table
+        """
+        self.row_id = input_json.get('row_id')
+        self.dba = input_json.get('DBA')
+        self.address = input_json.get('Address')
+        self.mrl = input_json.get('MRL#')
+        self.license_type = input_json.get('License Type')
+        self.violation_sent_date = input_json.get('Violation sent date')
+        self.original_violation_amount = input_json.get('Original Violation Amount')
+        self.admin_rvw_decision_date = input_json.get('Admin Rvw Decision Date')
+        self.admin_rvw_violation_amount = input_json.get('Admin Rvw Violation Amount')
+        self.certified_num = input_json.get('Certified #')
+        self.certified_reciept_returned = input_json.get('Certified receipt returned')
+        self.date_paid_waived = input_json.get('Date paid/ Waived')
+        self.receipt_no = input_json.get('Receipt No.')
+        self.cash_amt = input_json.get('Cash Amount')
+        self.check_amt = input_json.get('Check Amount')
+        self.card_amt = input_json.get('Card Amount')
+        self.check_num = input_json.get('Check No. / Approval Code')
+        self.notes = input_json.get('Notes')
+
+    def value_array(self):
+        """
+        Order data into an array that can be consumed by the row insertion method.
+        Returns ([]): array of data members
+        """
+        return [self.row_id, self.dba, self.address, self.mrl, self.license_type, self.violation_sent_date,
+                self.original_violation_amount, self.admin_rvw_decision_date, self.admin_rvw_violation_amount,
+                self.certified_num, self.certified_reciept_returned,
+                self.date_paid_waived, self.receipt_no, self.cash_amt,
+                self.check_amt, self.card_amt, self.check_num, self.notes]


### PR DESCRIPTION
Created reports.py/violations.py, updated driver.py with new tables in db_tables variable.  
db-create - added create statements for new tables.  Modified the archive table.  Instead of column for column copy of the intake, now just has a single column that holds JSON value of deleted row.  This matches how txn_history stores values.  Also allows for easier extensibility.  Removed the archive function and rolled it up into the change function.  Reducing number of function calls for each deletion.  Triggers created for new tables.  