### PR TITLE
Cap 112 export csv

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,7 +1,6 @@
-from flask import Flask, request, jsonify, Response, make_response, send_file
+from flask import Flask, request, jsonify, Response, make_response
 from flask_cors import CORS
 import driver
-import csv
 import pandas as pd
 from pandas.io.json import json_normalize
 from cors import cors_setup

--- a/server.py
+++ b/server.py
@@ -1,6 +1,9 @@
-from flask import Flask, request, jsonify, Response, make_response
+from flask import Flask, request, jsonify, Response, make_response, send_file
 from flask_cors import CORS
 import driver
+import csv
+import pandas as pd
+from pandas.io.json import json_normalize
 from cors import cors_setup
 from models.IntakeRow import IntakeRow
 
@@ -146,6 +149,25 @@ def show_metadata():
     response_body = jsonify(driver.get_table('metadata', None))
     return make_response(response_body, 200)
 
+@app.route('/export', methods=['GET'])
+def export_csv():
+    """
+    Returns a CSV file of the table listed in the request.
+    Usage:
+        GET /export?table=<table_name> to retrieve CSV of table
+    Returns ({}): CSV object of table data
+    """
+    if request.method == 'GET':
+        table_name = request.args.get('table')
+        if table_name is None:
+            return make_response(jsonify('Table name not supplied.'), 400)
+        try:
+            table_output = driver.get_table(table_name, None)
+            df = json_normalize(table_output)
+            df.to_csv('export.csv', index = False)
+            return send_file('export.csv', attachment_filename='export.csv')
+        except driver.InvalidTableException:
+            return make_response(jsonify('Table ' + table_name + ' does not exist.'), 404)
 
 @app.route('/')
 def hello_world():

--- a/server.py
+++ b/server.py
@@ -1,7 +1,6 @@
 from flask import Flask, request, jsonify, Response, make_response
 from flask_cors import CORS
 import driver
-import pandas as pd
 from pandas.io.json import json_normalize
 from cors import cors_setup
 from models.IntakeRow import IntakeRow

--- a/server.py
+++ b/server.py
@@ -152,9 +152,9 @@ def show_metadata():
 @app.route('/export', methods=['GET'])
 def export_csv():
     """
-    Returns a CSV file of the table listed in the request.
+    Returns CSV of the table listed in the request.
     Usage:
-        GET /export?table=<table_name> to retrieve CSV of table
+        GET /export?table=<table_name> -o outputfile.csv to retrieve CSV of table
     Returns ({}): CSV object of table data
     """
     if request.method == 'GET':
@@ -164,8 +164,8 @@ def export_csv():
         try:
             table_output = driver.get_table(table_name, None)
             df = json_normalize(table_output)
-            df.to_csv('export.csv', index = False)
-            return send_file('export.csv', attachment_filename='export.csv')
+            table_info_obj = df.to_csv(index = False)
+            return make_response(table_info_obj, 200)
         except driver.InvalidTableException:
             return make_response(jsonify('Table ' + table_name + ' does not exist.'), 404)
 


### PR DESCRIPTION
This PR introduced the /export endpoint for the API. This endpoint takes a table name as an argument and returns a csv object of all data from that postgresql table.

Example usage:
curl -X GET https://localhost/export?table=intake -o intake.csv